### PR TITLE
[FIX]: Documentation Fix for broken github link

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $ cd myprogram
 $ mkdir vendor
 $ cd vendor
 $ echo "(vendored_dirs *)" > dune
-$ git clone https://github.com/claidiusFX/claudius.git
+$ git clone https://github.com/claudiusFX/Claudius.git
 $ cd ..
 $ git submodule update --init --recursive
 ```


### PR DESCRIPTION
Fixes #97 

The broken link has been fixed and some typos are corrected. 