### PR TITLE
Fix dune/opam files having outdated giflib

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,11 @@ on:
       - main
   pull_request:
 
+env:
+  OPAMCRITERIA: +removed,+count[version-lag,solution]
+  OPAMFIXUPCRITERIA: +removed,+count[version-lag,solution]
+  OPAMUPGRADECRITERIA: +removed,+count[version-lag,solution]
+
 permissions: read-all
 
 jobs:

--- a/claudius.opam
+++ b/claudius.opam
@@ -27,7 +27,7 @@ depends: [
   "tsdl" {>= "1.1.0"}
   "ounit2" {with-test}
   "odoc" {with-doc}
-  "giflib" {>= "1.0.3"}
+  "giflib" {>= "1.1.0"}
   "imagelib" {>= "20221222"}
   "crunch" {>= "4.0.0"}
   "hsluv" {>= "0.1.0"}

--- a/dune-project
+++ b/dune-project
@@ -21,7 +21,7 @@
  (name claudius)
  (synopsis "A retro-style graphics library")
  (description "A functional style retro-graphics library for OCaml for building generative art, demos, and games.")
- (depends (ocaml (>= 5.1)) dune (tsdl (>= 1.1.0)) (ounit2 :with-test) (odoc :with-doc) (giflib (>= 1.0.3)) (imagelib (>= 20221222)) (crunch (>= 4.0.0)) (hsluv (>= 0.1.0)) (ocamlformat (and (>= 0.27.0) :with-dev-setup )))
+ (depends (ocaml (>= 5.1)) dune (tsdl (>= 1.1.0)) (ounit2 :with-test) (odoc :with-doc) (giflib (>= 1.1.0)) (imagelib (>= 20221222)) (crunch (>= 4.0.0)) (hsluv (>= 0.1.0)) (ocamlformat (and (>= 0.27.0) :with-dev-setup )))
  (tags
   (graphics rendering paletted)))
 


### PR DESCRIPTION
The most recent opam update for Claudius failed: https://github.com/ocaml/opam-repository/pull/28530

The reason was because opam sensibly tests packages with the minimum version of each dependancy as specified in the opam file, and when I moved Claudius to use the simplified giflib interface recently, I didn't update the version number in the dune-project file or Claudius.opam file. This was a bug our own CI missed, but thankfully the opam one detected.

In this PR I do two things:

1. I make our CI now do the same thing the opam CI does by specifying the same three environmental variables that the opam CI does which tell opam to install the minimum version of each package Claudius depends on. With that set, I could get our CI to also fail!
2. I updated dune-project and Claudius.opam to have the right version, making our CI then pass.